### PR TITLE
LT-41: Добавить OAuth-авторизацию в проект

### DIFF
--- a/build-ssr.sh
+++ b/build-ssr.sh
@@ -1,0 +1,9 @@
+cd packages/client
+yarn build
+yarn build:ssr 
+yarn link 
+cd ../server 
+yarn link client 
+yarn build
+cd ../../
+yarn dev:server

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "lerna run test",
     "lint": "lerna run lint",
     "format": "lerna run format",
-    "preview": "lerna run preview"
+    "preview": "lerna run preview",
+    "build:ssr": "sh build-ssr.sh"
   },
   "license": "MIT",
   "workspaces": [

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import './app/styles/App.scss';
 import { ToastContainer } from 'react-toastify';
 import { AppRouter } from './app/providers/router/AppRouter';

--- a/packages/client/src/app/providers/OAuth/helpers/getClientId.ts
+++ b/packages/client/src/app/providers/OAuth/helpers/getClientId.ts
@@ -1,0 +1,28 @@
+import type { AxiosRequestConfig } from 'axios';
+import { AxiosInstance } from '../../../../shared/axios/instance';
+import { BASE_URL, REDIRECT_URL } from '../../../../constants';
+import { TGetClientId } from './types';
+
+export const getClientId = async () => {
+  const params = {
+    redirect_uri: REDIRECT_URL,
+  };
+
+  const config: AxiosRequestConfig = {
+    url: `${BASE_URL}/oauth/yandex/service-id`,
+    method: 'GET',
+    params,
+    responseType: 'json',
+    withCredentials: true,
+  };
+
+  try {
+    const result = await AxiosInstance<TGetClientId>(config);
+    return result.data.service_id;
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      throw new Error(`Не удалось получить clientId`);
+    }
+    return '';
+  }
+};

--- a/packages/client/src/app/providers/OAuth/helpers/postAuth.ts
+++ b/packages/client/src/app/providers/OAuth/helpers/postAuth.ts
@@ -1,0 +1,21 @@
+import type { AxiosRequestConfig } from 'axios';
+import { AxiosInstance } from '../../../../shared/axios/instance';
+import { BASE_URL, REDIRECT_URL } from '../../../../constants';
+
+export const postAuth = async (code: string) => {
+  const data = {
+    code,
+    redirect_uri: REDIRECT_URL,
+  };
+
+  const config: AxiosRequestConfig = {
+    url: `${BASE_URL}/oauth/yandex`,
+    method: 'POST',
+    data,
+    responseType: 'json',
+    withCredentials: true,
+  };
+
+  const result = await AxiosInstance<unknown>(config);
+  return result.data === 'OK';
+};

--- a/packages/client/src/app/providers/OAuth/helpers/types.ts
+++ b/packages/client/src/app/providers/OAuth/helpers/types.ts
@@ -1,0 +1,19 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
+import { Dispatch } from 'react';
+import { StateProps } from '../../../../store/userSlice';
+
+export type TGetClientId = { service_id: string };
+
+type TState = {
+  user: StateProps;
+  helpers: StateProps;
+};
+
+export type TDispatch = ThunkDispatch<TState, undefined, AnyAction> &
+  Dispatch<AnyAction>;
+
+export type TGetCodeParam = (
+  location: ReturnType<typeof useLocation>,
+  navigate: ReturnType<typeof useNavigate>
+) => string;

--- a/packages/client/src/app/providers/OAuth/helpers/useCodeParam.ts
+++ b/packages/client/src/app/providers/OAuth/helpers/useCodeParam.ts
@@ -1,0 +1,13 @@
+import { TGetCodeParam } from './types';
+
+export const getCodeParam: TGetCodeParam = (location, navigate) => {
+  const code = new URLSearchParams(location.search).get('code');
+  if (!code) {
+    return '';
+  }
+  const replacedParams = location.search
+    .replace(/[?&]code=[^&]+/, '')
+    .replace(/^&/, '?');
+  navigate(location.pathname + replacedParams);
+  return code;
+};

--- a/packages/client/src/app/providers/OAuth/helpers/useOAuth.ts
+++ b/packages/client/src/app/providers/OAuth/helpers/useOAuth.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { getUser } from '../../../../store/userSlice';
+import { getCodeParam } from './useCodeParam';
+import { postAuth } from './postAuth';
+import { AppDispath } from '../../../../store';
+
+export const useOAuth = async () => {
+  const dispatch = useDispatch<AppDispath>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const tryOAuth = async () => {
+      const code = getCodeParam(location, navigate);
+      if (code) {
+        const auth = await postAuth(code);
+        if (!auth) {
+          toast.error('Не удалось залогиниться через OAuth');
+        }
+      }
+      await dispatch(getUser());
+    };
+
+    tryOAuth();
+  }, [dispatch, location, navigate]);
+};

--- a/packages/client/src/app/providers/OAuth/ui/AuthLink/index.tsx
+++ b/packages/client/src/app/providers/OAuth/ui/AuthLink/index.tsx
@@ -1,0 +1,23 @@
+import { FC, useEffect, useState } from 'react';
+import { REDIRECT_URL } from '../../../../../constants';
+import { getClientId } from '../../helpers/getClientId';
+import css from './styles.module.scss';
+
+export const AuthLink: FC = () => {
+  const [clientId, setClientId] = useState('');
+
+  useEffect(() => {
+    const fetchClientId = async () => {
+      const clientId = await getClientId();
+      setClientId(clientId);
+    };
+    fetchClientId();
+  }, []);
+  return (
+    <a
+      className={css.link}
+      href={`https://oauth.yandex.ru/authorize?response_type=code&client_id=${clientId}&redirect_uri=${REDIRECT_URL}`}>
+      Войти через Яндекс ID
+    </a>
+  );
+};

--- a/packages/client/src/app/providers/OAuth/ui/AuthLink/styles.module.scss
+++ b/packages/client/src/app/providers/OAuth/ui/AuthLink/styles.module.scss
@@ -1,0 +1,17 @@
+.link {
+  display: block;
+  background-color: black;
+  font-size: 14px;
+  height: 32px;
+  padding: 4px 15px;
+  border-radius: 6px;
+  color: #fff;
+  box-shadow: 0 2px 0 rgba(5, 145, 255, 0.1);
+  float: right;
+  width: 25.2rem;
+  text-align: center;
+}
+
+.link:hover {
+  color: #fff;
+}

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -1,0 +1,2 @@
+export const BASE_URL = 'https://ya-praktikum.tech/api/v2';
+export const REDIRECT_URL = 'http://localhost:3000';

--- a/packages/client/src/pages/HomePage/ui/homePage.tsx
+++ b/packages/client/src/pages/HomePage/ui/homePage.tsx
@@ -1,12 +1,15 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Layout } from 'antd';
 import cls from './homePage.module.scss';
 import { RoutePath } from '../../../app/providers/router/routeConfig';
 import seabattleImg from '../seabattle.png';
+import { useOAuth } from '../../../app/providers/OAuth/helpers/useOAuth';
 
 const { Content } = Layout;
 
 export const HomePage = () => {
+  useOAuth();
+
   const onClick = useCallback(() => {
     window.location.replace(RoutePath.game);
   }, []);

--- a/packages/client/src/pages/LoginPage/ui/loginPage.tsx
+++ b/packages/client/src/pages/LoginPage/ui/loginPage.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
 import { Layout, Button, Checkbox, Form } from 'antd';
 import { useNavigate } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useForm, Controller } from 'react-hook-form';
 import cls from './loginPage.module.scss';
 import { login, userActions } from '../../../store/userSlice';
@@ -12,10 +11,10 @@ import {
 } from '../../../shared/constants/validationConstants';
 import { ValidatableFormItemInput } from '../../../shared/ui/ValidatableFormItemInput/ValidatableFormItemInput';
 
-import { RoutePath } from '../../../app/providers/router/routeConfig';
 import PrimaryButton from '../../../shared/ui/PrimaryButton/PrimaryButton';
 
-import { AppDispath, RootState } from '../../../store';
+import { AppDispath } from '../../../store';
+import { AuthLink } from '../../../app/providers/OAuth/ui/AuthLink';
 
 const { Content } = Layout;
 
@@ -28,7 +27,6 @@ export type ILoginDataFieldType = {
 export const LoginPage = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispath>();
-  const { isAuth } = useSelector((s: RootState) => s.user);
 
   const {
     control,
@@ -56,16 +54,11 @@ export const LoginPage = () => {
     );
   };
 
-  useEffect(() => {
-    if (isAuth) {
-      navigate(RoutePath.home, { replace: true });
-    }
-  }, [isAuth, navigate]);
-
   return (
     <Layout className={cls.wrapper}>
       <Content className={cls.content}>
         <div className={cls.ship} />
+
         <Form
           className={cls.form}
           name="basic"
@@ -147,6 +140,7 @@ export const LoginPage = () => {
               Зарегистрироваться
             </Button>
           </Form.Item>
+          <AuthLink />
         </Form>
       </Content>
     </Layout>

--- a/packages/client/src/pages/profile.tsx
+++ b/packages/client/src/pages/profile.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Profile() {
-  return <h1>Страница профиля</h1>;
-}

--- a/packages/client/src/shared/ui/Header/Header.tsx
+++ b/packages/client/src/shared/ui/Header/Header.tsx
@@ -1,23 +1,19 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import React, { FC, useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import type { FC } from 'react';
 import { Button } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
 import { logout, userActions } from '../../../store/userSlice';
-
 import {
   AppRoutes,
   routeConfig,
-  RoutePath,
 } from '../../../app/providers/router/routeConfig';
 import cls from './Header.module.scss';
-
 import { AppDispath, RootState } from '../../../store';
 
 const Header: FC = () => {
   const dispatch = useDispatch<AppDispath>();
   const isAuth = useSelector((s: RootState) => s.user.isAuth);
   const isFullScreen = useSelector((s: RootState) => s.helpers.isFullScreen);
-  const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const onLogout = () => {
@@ -25,12 +21,6 @@ const Header: FC = () => {
     dispatch(userActions.clearError());
     dispatch(logout());
   };
-
-  useEffect(() => {
-    if (!isAuth && pathname !== `/${AppRoutes.REGISTRATION}`) {
-      navigate(RoutePath.login, { replace: true });
-    }
-  }, [isAuth, navigate, pathname]);
 
   return (
     <nav className={isFullScreen ? `${cls.navbar} hidden` : `${cls.navbar}`}>

--- a/packages/client/src/store/userSlice.ts
+++ b/packages/client/src/store/userSlice.ts
@@ -13,7 +13,7 @@ export interface isAuthState {
   isAuth: boolean;
 }
 
-interface StateProps {
+export interface StateProps {
   isAuth: boolean;
   isLoading?: boolean;
   error?: string;
@@ -136,6 +136,7 @@ export const userSlice = createSlice({
     builder.addCase(getUser.fulfilled, (state, action) => {
       state.isLoading = false;
       state.user = action.payload;
+      state.isAuth = true;
     });
   },
 });


### PR DESCRIPTION
Ожидания:
Есть возможность авторизации через Yandex OAuth.

Пояснение:
После авторизации будет происходить редирект на страницу с вашим проектом. Чтобы ссылка заработала, отправьте её вашему ментору с просьбой добавить в OAuth. Если тестируете проект локально, в качестве redirect_uri можно использовать http://localhost:3000/ (без слеша в конце, это важно). Ещё варианты портов: 5000, 9000. Если ваш проект локально использует другой порт и по какой-то причине вам нужен именно он, обратитесь к ментору.

Комментарий: 
При успешной авторизации вылетает одна ошибка "Cookie is invalid", что является ожидаемым поведением с React Strict. 